### PR TITLE
Fixed UnicodeDecodeError during checking available port

### DIFF
--- a/msl/loadlib/utils.py
+++ b/msl/loadlib/utils.py
@@ -199,7 +199,7 @@ def port_in_use(port):
         Whether the port is in use.
     """
     p = subprocess.Popen(['netstat', '-an'], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-    return p.communicate()[0].decode().find(':{} '.format(port)) > 0
+    return p.communicate()[0].decode(errors='ignore').find(':{} '.format(port)) > 0
 
 
 def get_available_port():


### PR DESCRIPTION
For System with RU default language, UnicodeDecodeError occurred by reason of Cyrillic headers in "netstat -an" output.