### PR TITLE
Add RPC timeout, fix freezing so it doesn't assume pyinstaller in the env is 32 bit, and facilities for the server to shut itself down.

### DIFF
--- a/msl/loadlib/__init__.py
+++ b/msl/loadlib/__init__.py
@@ -51,4 +51,7 @@ from . import utils
 from .load_library import LoadLibrary
 from .client64 import Client64
 from .server32 import Server32
-from .exceptions import Server32Error, ConnectionTimeoutError
+
+from .exceptions import Server32Error
+from .exceptions import ConnectionTimeoutError
+from .exceptions import ServerExit

--- a/msl/loadlib/client64.py
+++ b/msl/loadlib/client64.py
@@ -28,7 +28,7 @@ _encoding = sys.getfilesystemencoding()
 
 class Client64(object):
 
-    def __init__(self, module32, host='127.0.0.1', port=None, timeout=10.0, quiet=True,
+    def __init__(self, module32, host='127.0.0.1', port=None, timeout=10.0, rpc_timeout=10.0, quiet=True,
                  append_sys_path=None, append_environ_path=None, **kwargs):
         """Base class for communicating with a 32-bit library from 64-bit Python.
 
@@ -50,6 +50,9 @@ class Client64(object):
         timeout : :class:`float`, optional
             The maximum number of seconds to wait to establish a connection to the
             32-bit server. Default is 10 seconds.
+        rpc_timeout : :class:`float`, optional
+            The maximum number of seconds to wait for a RPC response. Defaults to
+            10 seconds.
         quiet : :class:`bool`, optional
             Whether to hide :data:`sys.stdout` messages on the 32-bit server.
             Default is :data:`True`.
@@ -159,7 +162,7 @@ class Client64(object):
             raise
 
         # start the connection
-        self._conn = HTTPConnection(host, port)
+        self._conn = HTTPConnection(host=host, port=port, timeout=rpc_timeout)
         self._is_active = True
         self._meta32 = self.request32('_SERVER32_METADATA_')
 
@@ -189,7 +192,7 @@ class Client64(object):
     @property
     def lib32_path(self):
         """The path to the 32-bit library.
-        
+
         Returns
         -------
         :class:`str`
@@ -236,9 +239,9 @@ class Client64(object):
 
     def shutdown_server32(self):
         """Shutdown the 32-bit server.
-        
+
         This method stops the process that is running the 32-bit server executable
-        and it deletes the temporary file that is used to save the serialized 
+        and it deletes the temporary file that is used to save the serialized
         :mod:`pickle`\'d data.
 
         Note

--- a/msl/loadlib/exceptions.py
+++ b/msl/loadlib/exceptions.py
@@ -12,6 +12,13 @@ from . import IS_PYTHON2
 class ConnectionTimeoutError(OSError):
     """Raised when the connection to the 32-bit server cannot be established."""
 
+class ServerExit(Exception):
+    '''
+    Raised by the server thread to inform the HTTPServer it wants to stop.
+    This is much cleaner then just calling terminate() (the server can do
+    cleanup this way).
+    '''
+    pass
 
 class Server32Error(HTTPException):
 

--- a/msl/loadlib/freeze_server32.py
+++ b/msl/loadlib/freeze_server32.py
@@ -46,7 +46,7 @@ def main(spec=None, requires_pythonnet=True, requires_comtypes=True):
     Parameters
     ----------
     spec : :class:`str`, optional
-        If you want to freeze using a PyInstaller_ .spec file then you can specify the 
+        If you want to freeze using a PyInstaller_ .spec file then you can specify the
         path to the .spec file.
     requires_pythonnet : :class:`bool`, optional
         Whether `Python for .NET`_ must be available on the 32-bit server.
@@ -89,7 +89,11 @@ def main(spec=None, requires_pythonnet=True, requires_comtypes=True):
 
     here = os.path.abspath(os.path.dirname(__file__))
     cmd = [
-        'pyinstaller',
+        # Specifically invoke pyinstaller in the context of the current
+        # python interpreter. This fixes the issue where the blind `pyinstaller`
+        # invocation points to a 64-bit version.
+        sys.executable,
+        '-m', 'PyInstaller',
         '--distpath', here,
         '--noconfirm',
     ]


### PR DESCRIPTION
Basically the title:

 - 82b3a43 adds a timeout to RPC calls, so you can handle contexts where the remote goes away or gets stuck forever.
 - 0371582 Fixes the fact that `freeze_server32.py` assumes that invoking `PyInstaller` in the shell will point to the *32* bit pyinstaller binary. I literally have python32 for this project, and nothing else, and it's not on the `PATH`, so I wound up accidentally building a 64-bit server32 (which unsurprisingly didn't work at all)  
Rather then just invoking pyinstaller, it now looks at how the script file itself was invoked, and uses that to then execute `<python cmd> -m PyInstaller ...`. This will probably help for other oddbal environments too.
 - 3ec1c33 adds a new exception (`ServerExit`), which the server can raise and will cause the server to gracefully shutdown. This is somewhat nicer then the brute-force `_proc.terminate()` that's currently relied upon, and should let the server do any cleanup too.  
I needed this because my server class fires up some worker threads, and terminate would just orphan them.

The various commits should be cherry-pickable, if needed.