### PR TITLE
Add overridable shutdown handler that's called upon shutdown

### DIFF
--- a/msl/loadlib/server32.py
+++ b/msl/loadlib/server32.py
@@ -144,8 +144,8 @@ class Server32(HTTPServer):
     @staticmethod
     def interactive_console():
         """Start an interactive console.
-        
-        This method starts an interactive console, in a new terminal, with the 
+
+        This method starts an interactive console, in a new terminal, with the
         Python interpreter on the 32-bit server.
 
         Examples
@@ -168,6 +168,15 @@ class Server32(HTTPServer):
         return self._quiet
 
 
+    def shutdown_handler(self):
+        '''
+        Empty proxy function that's called immediately prior to the server shutting down.
+
+        The intended use case is for the server to do any necessary cleanup, such as stopping
+        locally started threads, closing file-handles, etc....
+        '''
+        pass
+
 class RequestHandler(BaseHTTPRequestHandler):
     """Handles the request that was sent to the 32-bit server."""
 
@@ -178,6 +187,7 @@ class RequestHandler(BaseHTTPRequestHandler):
             if method == METADATA:
                 response = {'path': self.server.path, 'pid': os.getpid()}
             elif method == SHUTDOWN:
+                self.server.shutdown_handler()
                 threading.Thread(target=self.server.shutdown).start()
                 return
             else:


### PR DESCRIPTION
This is a minor extension to https://github.com/MSLNZ/msl-loadlib/pull/18.

Right now, there's no way to attach to the server's `-SHUTDOWN-` handler, which means that any teardown procedure must be two step: call user-code that does server shutdown, then actually stop the server.

I don't like this, because it means you wind up having a new system state, where the server is partially stopped. I'd much rather the entire halt process be a single function invocation.   
Sure, this is a bit OCD, but in my experience, if you add new system states, you'll almost inevitably wind up stuck in them *somehow*.

Anyways, basically this PR just adds a `shutdown_handler()` function that's called before the actual server shutdown by the request handler. Normally, it does nothing, but user-code can override it and do it's teardown there.